### PR TITLE
Store “apilogin” authToken in the environment, use it to authenticate all further requests

### DIFF
--- a/WoodWing Assets.postman_collection.json
+++ b/WoodWing Assets.postman_collection.json
@@ -88,6 +88,18 @@
 					"item": [
 						{
 							"name": "Login using 'apilogin'",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var data = pm.response.json();",
+											"pm.environment.set(\"Current AUTH-TOKEN\", data.authToken);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "POST",
 								"header": [],
@@ -2813,6 +2825,16 @@
 			]
 		}
 	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{Current AUTH-TOKEN}}",
+				"type": "string"
+			}
+		]
+	},
 	"event": [
 		{
 			"listen": "prerequest",


### PR DESCRIPTION
On successful “apilogin”, automatically store the authToken in an environment variable "Current AUTH-TOKEN". 
Use that variable as bearer token for authenticating all requests in the collection.
This means that the user can run the “Login using 'apilogin'” request once, and all further requests in the collection are automatically authenticated.